### PR TITLE
Fixed wget call

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:alpine
 
 RUN apk update && apk add --no-progress -q wget unzip
 
-RUN wget -O akaunting.zip https://akaunting.com/download.php?version=latest&utm_source=docker&utm_campaign=developers
+RUN wget -O akaunting.zip "https://akaunting.com/download.php?version=latest&utm_source=docker&utm_campaign=developers"
 RUN mkdir -p /var/www/akaunting
 RUN unzip akaunting.zip -d /var/www/akaunting
 RUN rm akaunting.zip


### PR DESCRIPTION
Shell run wget as daemon when it encounter the first '&' making docker build fail. Putting quotes around fixes it.