### PR TITLE
Fix typo in files/html/.env

### DIFF
--- a/files/html/.env
+++ b/files/html/.env
@@ -1,4 +1,4 @@
-PP_NAME=Akaunting
+APP_NAME=Akaunting
 APP_ENV=production
 APP_LOCALE=en-US
 APP_INSTALLED=true


### PR DESCRIPTION
Not sure what this file's used for, but I noticed a typo.