### PR TITLE
Re-add ARM 64-bit images

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           context: .
           file: ./${{ matrix.file }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.image-tags.outputs.tags }}
       - name: Build and push images
@@ -93,6 +93,6 @@ jobs:
         with:
           context: .
           file: ./${{ matrix.file }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.image-tags.outputs.tags }}


### PR DESCRIPTION
Hey Akaunting team! We are adding Akaunting to our [self-hosted App Store](https://kubesail.com/templates) and just noticed that ARM support was dropped recently in [this commit](https://github.com/akaunting/docker/commit/54bbeaf4b9b875ff22b97ad7f29295267188342f). It looks like the build [failed for only ARMv6](https://github.com/akaunting/docker/runs/6684822830?check_suite_focus=true#step:8:2710), which is fairly old at this point. Would you consider adding at least arm64 back, as in this PR?

We offer a Raspberry Pi powered device (https://pibox.io/) which perfect for hosting Akaunting, but the Pi is an ARM machine which is why we'd like to see support added back. Hopefully this is not too much trouble!

I'm working on getting the App Template working today. It's a Kubernetes config which is similiar to the docker-compose config, and will be available at https://kubesail.com/template/pastudan/Akaunting.

On a related note, we just started an open-source affiliate program for the PiBox. For example, if you link your users who are interested in self-hosting Akaunting to https://pibox.io/order/platform/akaunting then we are able to send a portion of each sale of the PiBox back to open source & self hosted projects. If this is interesting, feel free to reach out. Otherwise no worries!