### PR TITLE
Clarify that port number should be specified if running locally

### DIFF
--- a/env/run.env.example
+++ b/env/run.env.example
@@ -1,4 +1,4 @@
-# You should change this to match your reverse proxy DNS name and protocol
+# You should change this to match your reverse proxy protocol, DNS name and port (if non standard port is used)
 APP_URL=https://akaunting.example.com
 LOCALE=en-US
 


### PR DESCRIPTION
resolves #71 

When launching the app locally with docker-compose with default port (8080) exposed and without using additional reverse proxy, the port number should be explicitly specified for the app to work.

This PR introduces a minor edit to the comment in the example .env file to clarify the need to specify the port