### PR TITLE
Addition to run.env as db variable is different when running AKAUNTIN…

### DIFF
--- a/env/run.env.example
+++ b/env/run.env.example
@@ -8,6 +8,7 @@ DB_PORT=3306
 
 # Change these to match env/db.env
 DB_NAME=akaunting
+DB_DATABASE=akaunting #This is the same as DB_NAME as the variable is doffrent between AKAUNTING_SETUP=true/false
 DB_USERNAME=admin
 DB_PASSWORD=akaunting_password
 


### PR DESCRIPTION
Addition to run.env as db variable is different when running AKAUNTING_SETUP=true vs AKAUNTING_SETUP=false